### PR TITLE
Fix min values for Message.nextSend and Scheduler.nextSend.

### DIFF
--- a/grails-app/domain/mama/ng/scheduler/Message.groovy
+++ b/grails-app/domain/mama/ng/scheduler/Message.groovy
@@ -11,6 +11,6 @@ class Message {
     static constraints = {
         id generator:'assigned'
         schedule(nullable: false)
-        nextSend(min: new Date(), nullable: false)
+        nextSend(nullable: false)
     }
 }

--- a/grails-app/domain/mama/ng/scheduler/Schedule.groovy
+++ b/grails-app/domain/mama/ng/scheduler/Schedule.groovy
@@ -20,7 +20,7 @@ class Schedule {
         sendCounter(min: 0, nullable: false)
         cronDefinition(matches: CronDefinition.REGEX,
             nullable: false, blank: false)
-        nextSend(min: new Date(), nullable: false)
+        nextSend(nullable: false)
         endpoint(url: true, blank: false, nullable: false)
     }
 }

--- a/test/unit/mama/ng/scheduler/MessageSpec.groovy
+++ b/test/unit/mama/ng/scheduler/MessageSpec.groovy
@@ -66,8 +66,7 @@ class MessageSpec extends Specification {
                 message.save()
             }
         expect:
-            message.hasErrors()
-            message.errors["nextSend"].equals("min")
+            !message.hasErrors()
     }
 
     void "test null nextSend"() {

--- a/test/unit/mama/ng/scheduler/ScheduleSpec.groovy
+++ b/test/unit/mama/ng/scheduler/ScheduleSpec.groovy
@@ -126,8 +126,7 @@ class ScheduleSpec extends Specification {
                 schedule.save()
             }
         expect:
-            schedule.hasErrors()
-            schedule.errors["nextSend"].toString().contains("min")
+            !schedule.hasErrors()
     }
 
     void "test null nextSend"() {


### PR DESCRIPTION
Currently these are both set to `new Date()`. As described in http://grails.github.io/grails-doc/2.4.4/ref/Constraints/min.html these are evaluated when the constraints are evaluated which makes `new Date()` a very bad idea for a minimum (e.g. existing objects in the database might fail to validate).

Probably it is best to just not have a minimum.
