### PR TITLE
When a schedule fires, the message parameters should be posted in the HTTP body, not as query parameters.

### DIFF
--- a/grails-app/services/mama/ng/scheduler/HttpRequestService.groovy
+++ b/grails-app/services/mama/ng/scheduler/HttpRequestService.groovy
@@ -12,16 +12,14 @@ import groovyx.net.http.Method
 class HttpRequestService {
 
 
-    Boolean postText(String baseUrl, Map body, method = Method.POST) {
+    Boolean postText(String url, Map bodyParams, method = Method.POST) {
         try {
             def ret = null
-            def http = new HTTPBuilder(baseUrl)
+            def http = new HTTPBuilder()
             http.contentEncoding = ContentEncoding.Type.DEFLATE
-
-            // perform a POST request, expecting TEXT response
-            http.request(method, ContentType.JSON) {
-                uri.query = body
-                headers.'User-Agent' = 'Mozilla/5.0 Ubuntu/8.10 Firefox/3.0.4'
+            http.request(url, method, ContentType.JSON) {
+                headers.'User-Agent' = 'mama-ng-scheduler-bot/0.1 (+http://https://github.com/praekelt/mama-ng-scheduler)'
+                body = bodyParams
 
                 // response handler for a success response code
                 response.success = { resp, reader ->
@@ -29,7 +27,6 @@ class HttpRequestService {
                 }
             }
             return ret
-
         } catch (HttpResponseException ex) {
             ex.printStackTrace()
             return null

--- a/test/unit/mama/ng/scheduler/HttpRequestServiceSpec.groovy
+++ b/test/unit/mama/ng/scheduler/HttpRequestServiceSpec.groovy
@@ -1,0 +1,72 @@
+package mama.ng.scheduler
+
+import grails.test.mixin.TestFor
+import groovy.mock.interceptor.MockFor
+import groovyx.net.http.ContentEncoding
+import groovyx.net.http.ContentType
+import groovyx.net.http.HTTPBuilder
+import groovyx.net.http.Method
+import spock.lang.Specification
+
+@TestFor(HttpRequestService)
+class HttpRequestServiceSpec extends Specification {
+
+    def httpMock
+    def success
+    def requestParameters
+    def contentEncoding
+
+    def setup() {
+        requestParameters = []
+        httpMock = new MockFor(HTTPBuilder.class)
+        def requestDelegate = [
+            response: [
+                'statusLine': [
+                    'protocol': 'HTTP/1.1',
+                    'statusCode': 200,
+                    'status':'OK',
+                ],
+            ],
+        ]
+
+        httpMock.demand.setContentEncoding(1) {
+            ContentEncoding.Type encoding ->
+            contentEncoding = encoding
+        }
+
+        httpMock.demand.request(1) {
+            Object uri, Method method, ContentType contentType, Closure c ->
+            c.delegate = requestDelegate
+            c.headers = [:]
+            c.call()
+            requestParameters = [uri: uri, method: method, contentType: contentType, headers: c.headers, body: c.body ]
+            if (success) {
+                requestDelegate.response.success(requestDelegate.response, [:])
+            }
+        }
+    }
+
+    def cleanup() {
+    }
+
+    void "test successful postText"() {
+        def ret
+
+        given:
+            success = true
+
+        when:
+            httpMock.use {
+                ret = service.postText("http://example.com/", [foo: 'bar'])
+            }
+
+        then:
+            requestParameters.uri == "http://example.com/"
+            requestParameters.method == Method.POST
+            requestParameters.contentType == ContentType.JSON
+            requestParameters.headers == ['User-Agent': 'mama-ng-scheduler-bot/0.1 (+http://https://github.com/praekelt/mama-ng-scheduler)']
+            requestParameters.body == [foo: 'bar']
+            contentEncoding == ContentEncoding.Type.DEFLATE
+            ret == true
+    }
+}


### PR DESCRIPTION
![screenshot from 2015-05-21 17 53 26](https://cloud.githubusercontent.com/assets/165551/7752895/58a5f7c8-ffe2-11e4-9186-425fa5be5f73.png)
