### PR TITLE
Add script for nicely restarting docker container after it exits.

### DIFF
--- a/scripts/start-docker-container.sh
+++ b/scripts/start-docker-container.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+#
+# Run a docker container after cleaning up any existing container with the same name.
+#
+# Usage:
+#    start-docker-container.sh <name> [<extra-docker-run-argument> ...]
+#
+# Example:
+#    start-docker-container.sh my-container --link redis:redis -p 8080:8080 group/container-type
+
+USAGE="Usage: $0 <name> [<extra-docker-run-argument> ...]"
+if [ "$#" == "0" ]; then
+    echo "$USAGE"
+    exit 1
+fi
+
+CONTAINER_NAME="$1"
+shift
+
+docker rm -f "$CONTAINER_NAME" || true
+docker run --rm --name="$CONTAINER_NAME" "$@"


### PR DESCRIPTION
Currently it's a little tricky to run the docker container from tools like supervisord because there is no script to help clean up any existing docker container instance before starting a new one.
