### PR TITLE
Set server port to 8000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Praekelt Foundation <dev@praekeltfoundation.org>
 COPY . /app
 WORKDIR /app
 
-EXPOSE 8090
+EXPOSE 8000
 
 RUN grails prod war
 CMD ["prod", "run-war"]

--- a/README.rst
+++ b/README.rst
@@ -41,8 +41,8 @@ it to the postgres container we just started::
 
     docker run --rm --name=mama-ng-scheduler \
         --link=postgresql:postgresql \
-        -p 8090:8090 \
+        -p 8000:8000 \
         -e DATABASE_URL="postgresql://scheduler:scheduler@postgresql:5432/scheduler" \
         praekelt/mama-ng-scheduler
 
-You can now access it on your docker container's IP address on port ``8090``.
+You can now access it on your docker container's IP address on port ``8000``.

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -5,7 +5,7 @@ grails.project.test.reports.dir = "target/test-reports"
 grails.project.work.dir = "target/work"
 grails.project.target.level = 1.6
 grails.project.source.level = 1.6
-grails.server.port.http = 8090
+grails.server.port.http = 8000
 //grails.project.war.file = "target/${appName}-${appVersion}.war"
 
 grails.project.fork = [


### PR DESCRIPTION
I'm trying to standardise on port 8000 for all the mama-ng containers (Marathon automatically maps to some other port on the host).
