### PR TITLE
Add .dockerignore to ignore git files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Ignore git files
+.git
+.gitignore
+
+# Ignore files git ignores
+.idea
+*.iml
+target
+out


### PR DESCRIPTION
Every time a git operation is performed (even if those operations didn't change any of the project files), some files in `.git` change which invalidates the Docker cache and causes Docker to think that (relevant) files have changed when they haven't.

Add a `.dockerignore` file to ignore `.git` and any other files which don't matter to the Docker build.
